### PR TITLE
Webpack improvements

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "generate-assets": "npx ts-node src/loader/generate-asset-lists.ts",
     "build": "webpack",
-    "start": "npm run build && live-server --port=8083",
+    "build:prod": "webpack --mode production",
+    "start": "npm run build:prod && live-server --port=8083",
     "dev": "webpack --watch & live-server --port=4949"
   },
   "repository": {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -43,28 +43,26 @@ module.exports = (_, argv) => {
           ],
           splitChunks: {
             chunks: 'all',
-            minSize: 20000,
-            maxSize: 244000,
+            maxSize: 500000,
             cacheGroups: {
               phaser: {
                 test: /[\\/]node_modules[\\/](phaser|phaser3-rex-plugins)[\\/]/,
                 name: 'phaser',
                 chunks: 'all',
-                priority: 10,
+                priority: 20,
               },
               vendor: {
                 test: /[\\/]node_modules[\\/]/,
-                name(module) {
-                  const packageName = module.context.match(
-                    /[\\/]node_modules[\\/](.*?)([\\/]|$)/,
-                  )[1]
-                  return `vendor.${packageName.replace('@', '')}`
-                },
+                name: 'vendor',
+                chunks: 'all',
+                priority: 10,
               },
               common: {
                 name: 'common',
                 minChunks: 2,
-                priority: -10,
+                chunks: 'all',
+                priority: 5,
+                reuseExistingChunk: true,
               },
             },
           },


### PR DESCRIPTION
Changing webpack.config.json to apply chunk loading to production build
Parallelizes loading Phaser on the main thread

Prior config create 33 js files -> lowered to 20 js files:
Consolidated vendor file to improve caching
500kb max chunk size creates 13 phaser chunks, 6 main chunks, 1 vendor chunk