### PR TITLE
Stripe.js improvements

### DIFF
--- a/client/src/scene/menu/menu.ts
+++ b/client/src/scene/menu/menu.ts
@@ -158,7 +158,6 @@ import FocusMenu from './focus'
 import SearchMenu from './search'
 import LeaderboardMenu from './leaderboard'
 import { RegisterUsernameMenu } from './registerUsername'
-import PurchaseGemsMenu from './purchaseGems'
 import PurchaseItemMenu from './purchaseItem'
 import UserProfileMenu from './userProfile'
 import AchievementsMenu from './achievements'
@@ -178,17 +177,27 @@ const menus = {
   search: SearchMenu,
   leaderboard: LeaderboardMenu,
   registerUsername: RegisterUsernameMenu,
-  purchaseGems: PurchaseGemsMenu,
+  purchaseGems: null, // Lazy-loaded to avoid loading Stripe on app startup
   purchaseItem: PurchaseItemMenu,
   userProfile: UserProfileMenu,
   achievements: AchievementsMenu,
 }
 
 // Function exposed for the creation of custom menus
-export function createMenu(scene: Phaser.Scene, title: string, params): Menu {
+export async function createMenu(
+  scene: Phaser.Scene,
+  title: string,
+  params,
+): Promise<Menu> {
   // Check if the given menu exists, if not throw
   if (!(title in menus)) {
     throw `Given menu ${title} is not in list of implemented menus.`
+  }
+
+  // Lazy-load purchaseGems menu to avoid loading Stripe eagerly
+  if (title === 'purchaseGems' && !menus.purchaseGems) {
+    const module = await import('./purchaseGems')
+    menus.purchaseGems = module.default
   }
 
   return new menus[title](scene, params)

--- a/client/src/scene/menuScene.ts
+++ b/client/src/scene/menuScene.ts
@@ -29,7 +29,7 @@ export default class MenuScene extends BaseMenuScene {
     })
   }
 
-  create(params): void {
+  async create(params): Promise<void> {
     super.create(params)
 
     // Hide hint on all active scenes
@@ -45,7 +45,7 @@ export default class MenuScene extends BaseMenuScene {
 
     this.addBackground()
 
-    this.menu = createMenu(this, params.menu, params)
+    this.menu = await createMenu(this, params.menu, params)
 
     // When esc is pressed, close this scene
     let esc = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC)

--- a/client/src/store/paymentService.ts
+++ b/client/src/store/paymentService.ts
@@ -4,7 +4,14 @@ import { PAYMENT_PORT } from '../../../shared/network/settings'
 import { Flags } from '../settings/flags'
 import Server from '../server'
 
-const stripePromise = loadStripe(Url.stripePublishableKey)
+let stripePromise: ReturnType<typeof loadStripe> | null = null
+
+function getStripePromise() {
+  if (!stripePromise) {
+    stripePromise = loadStripe(Url.stripePublishableKey)
+  }
+  return stripePromise
+}
 
 export const paymentService = {
   // Initialize a purchase for gems
@@ -45,7 +52,7 @@ export const paymentService = {
 
   // Open Stripe Checkout
   async openCheckout(sessionId: string): Promise<boolean> {
-    const stripe = await stripePromise
+    const stripe = await getStripePromise()
     if (!stripe) throw new Error('Stripe failed to initialize')
 
     const { error } = await stripe.redirectToCheckout({


### PR DESCRIPTION
Stripe.js library imports block main thread from loading splash screen and intro animation
Preload controller occupies ~3-4 seconds

Changes eager loading at module import time to lazy loading at gem checkout
Dynamically loads when user navigates to store menu